### PR TITLE
Allows static satellite to come from external URL

### DIFF
--- a/R/LoadSatellites.R
+++ b/R/LoadSatellites.R
@@ -68,8 +68,14 @@ loadSatTables <- function(model) {
     # Check if the satellite table uses a static file. If so, proceed.
     # If not, use specified functions in model metadata to load data from dynamic source
     if(!is.null(sat$StaticFile)) {
-      totals_by_sector <- utils::read.table(system.file("extdata", sat$StaticFile, package = "useeior"),
+      #If the file is a URL tested by the first 4 characters of the string = "http", don't wrap in system.file()
+      if (substring(sat$StaticFile,0,4)=="http") {
+        totals_by_sector <- utils::read.table(z,sep = ",", header = TRUE, stringsAsFactors = FALSE)  
+      } else {
+      
+        totals_by_sector <- utils::read.table(system.file("extdata", sat$StaticFile, package = "useeior"),
                                             sep = ",", header = TRUE, stringsAsFactors = FALSE)
+      }
     } else {
       func_to_eval <- sat$ScriptFunctionCall
       totalsgenfunction <- as.name(func_to_eval)

--- a/R/LoadSatellites.R
+++ b/R/LoadSatellites.R
@@ -68,13 +68,12 @@ loadSatTables <- function(model) {
     # Check if the satellite table uses a static file. If so, proceed.
     # If not, use specified functions in model metadata to load data from dynamic source
     if(!is.null(sat$StaticFile)) {
-      #If the file is a URL tested by the first 4 characters of the string = "http", don't wrap in system.file()
-      if (substring(sat$StaticFile,0,4)=="http") {
-        totals_by_sector <- utils::read.table(z,sep = ",", header = TRUE, stringsAsFactors = FALSE)  
+      # If the file is a URL tested by the first 4 characters of the string = "http", don't wrap in system.file()
+      if (substring(sat$StaticFile, 0, 4)=="http") {
+        totals_by_sector <- utils::read.table(sat$StaticFile, sep = ",", header = TRUE, stringsAsFactors = FALSE)  
       } else {
-      
         totals_by_sector <- utils::read.table(system.file("extdata", sat$StaticFile, package = "useeior"),
-                                            sep = ",", header = TRUE, stringsAsFactors = FALSE)
+                                              sep = ",", header = TRUE, stringsAsFactors = FALSE)
       }
     } else {
       func_to_eval <- sat$ScriptFunctionCall

--- a/inst/extdata/USEEIOv2.0.yml
+++ b/inst/extdata/USEEIOv2.0.yml
@@ -12,26 +12,26 @@ CommoditybyIndustryType: "Commodity"
 ScrapIncluded: FALSE
 
 SatelliteTable:
-  WAT:
-    FullName: "Water withdrawals"
-    Abbreviation: "WAT"
-    StaticSource: FALSE
-    StaticFile: null
-    DataYears: [2015]
-    Locations: ["US"]
-    SectorListSource: "NAICS"
-    SectorListYear: 2012
-    SectorListLevel: "6"
-    OriginalFlowSource: "FEDEFLv1.0.4"
-    ScriptFunctionCall: "getFlowbySectorCollapsed" #function to call for script
-    ScriptFunctionParameters: ["Water_national_2015_m1"] #list of parameters
-    DataSources:
-      USGS_NWIS_WU_2015:
-        Title: "Water Use in the US"
-        Author: "USGS"
-        DataYear: 2015
-        URL: "https://waterdata.usgs.gov/"
-        Primary: TRUE
+  # WAT:
+  #   FullName: "Water withdrawals"
+  #   Abbreviation: "WAT"
+  #   StaticSource: FALSE
+  #   StaticFile: null
+  #   DataYears: [2015]
+  #   Locations: ["US"]
+  #   SectorListSource: "NAICS"
+  #   SectorListYear: 2012
+  #   SectorListLevel: "6"
+  #   OriginalFlowSource: "FEDEFLv1.0.4"
+  #   ScriptFunctionCall: "getFlowbySectorCollapsed" #function to call for script
+  #   ScriptFunctionParameters: ["Water_national_2015_m1"] #list of parameters
+  #   DataSources:
+  #     USGS_NWIS_WU_2015:
+  #       Title: "Water Use in the US"
+  #       Author: "USGS"
+  #       DataYear: 2015
+  #       URL: "https://waterdata.usgs.gov/"
+  #       Primary: TRUE
   # CHAIR:
   #   FullName: "Criteria and Hazardous Air Emissions"
   #   Abbreviation: "CHAIR"
@@ -154,18 +154,30 @@ SatelliteTable:
   #   SectorListLevel: "Detail"
   #   OriginalFlowSource: "MINE"
   #   DataSources:
-  # ENERGY:
-  #   FullName: "Energy extraction"
-  #   Abbreviation: "ENERGY"
-  #   StaticSource: FALSE
-  #   StaticFile: "USEEIO_Energy_Data_Extracted_v1.1.csv"
-  #   DataYears: []
-  #   Locations: ["US"]
-  #   SectorListSource: "BEA"
-  #   SectorListYear: 2012
-  #   SectorListLevel: "Detail"
-  #   OriginalFlowSource: "MINE"
-  #   DataSources:
+  ENERGY:
+    FullName: "Energy extraction"
+    Abbreviation: "ENERGY"
+    StaticSource: TRUE
+    StaticFile: "https://edap-ord-data-commons.s3.amazonaws.com/USEEIO-input/USEEIOv1.1_Energy_TotalsBySector.csv"
+    DataYears: [2014]
+    Locations: ["US"]
+    SectorListSource: "BEA"
+    SectorListYear: 2007
+    SectorListLevel: "Detail"
+    OriginalFlowSource: "ENERGY"
+    DataSources:
+      EIA_MER:
+        Title: "Monthly Energy Review"
+        Author: "EIA"
+        DataYear: 2014
+        URL: "http://www.eia.gov/totalenergy/data/monthly/"
+        Primary: TRUE
+      EIA_923:
+        Title: "Form EIA-923 Detailed"
+        Author: "EIA"
+        DataYear: 2014
+        URL: "https://www.eia.gov/electricity/data/eia923/"
+        Primary: TRUE
   # NPAG:
   #   FullName: "Nitrogen and Phosphorus Releases from Agriculture"
   #   Abbreviation: "NPAG"


### PR DESCRIPTION
Tested with USEEIOv1.1_Energy_TotalsBySector
Loads it from the URL instead of  the local inst/ext 
handling is super simple..no change to config YAML; just a simple check for "http" in the front of the static file for removing the system.file() wrapper inside the read.table()
If this works for others, we can continue editing in another branch and close this feature branch


