### PR TITLE
scheduled action to add issue from template

### DIFF
--- a/.github/ISSUE_TEMPLATE/data_update.md
+++ b/.github/ISSUE_TEMPLATE/data_update.md
@@ -1,0 +1,11 @@
+---
+name: Data Update
+about: Reminders to assess new data releases.
+title: "Review annual BEA release"
+labels:
+  - "data update"
+---
+
+Review available BEA data updates
+
+https://www.bea.gov/news/schedule

--- a/.github/workflows/data_update.yaml
+++ b/.github/workflows/data_update.yaml
@@ -1,0 +1,18 @@
+# Creates an issue from a template based on schedule
+# See example: https://jasonet.co/posts/scheduled-actions/#jasonetcocreate-an-issue
+
+name: Data download reminder
+on:
+  schedule:
+    - cron: '0 0 15 9 *' # Runs on Sept 15 0:00 UTC
+  workflow_dispatch:
+jobs:
+  issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JasonEtco/create-an-issue@v2.6.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/data_update.md


### PR DESCRIPTION
Issue template designed to track annual BEA data releases

Syntax and formatting of the issue template can be expanded as desired: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms 

see also: https://github.com/JasonEtco/create-an-issue#inputs