### PR TITLE
Fixes #262. Sets M and N to respective domestic versions in calculateEEIOmodel

### DIFF
--- a/R/CalculationFunctions.R
+++ b/R/CalculationFunctions.R
@@ -16,8 +16,12 @@ calculateEEIOModel <- function(model, perspective, demand = "Production", use_do
   # Generate Total Requirements (L or L_d) matrix based on whether "use_domestic"
   if (use_domestic_requirements) {
     L <- model$L_d
+    M <- model$M_d
+    N <- model$N_d
   } else {
     L <- model$L
+    M <- model$M
+    N <- model$N
   }
   
   # Prepare demand vector
@@ -58,10 +62,10 @@ calculateEEIOModel <- function(model, perspective, demand = "Production", use_do
   } else if (perspective=="FINAL") {
     # Calculate Final Perspective LCI (a matrix with total impacts in form of sector x flows)
     logging::loginfo("Calculating Final Perspective LCI...")
-    result$LCI_f <- calculateFinalPerspectiveLCI(model$M, f)
+    result$LCI_f <- calculateFinalPerspectiveLCI(M, f)
     # Calculate Final Perspective LCIA (matrix with total impacts in form of sector x impacts)
     logging::loginfo("Calculating Final Perspective LCIA...")
-    result$LCIA_f <- calculateFinalPerspectiveLCIA(model$N, f)
+    result$LCIA_f <- calculateFinalPerspectiveLCIA(N, f)
   }
   
   logging::loginfo("Result calculation complete.")


### PR DESCRIPTION
@bl-young please determine the best place to pull this fix into and merge when ready

Performed this test to check that this fix is valid

```
## Test that the fix to the FINAL perspective calc for domestic models is valid (useeior issue #262)

library(devtools)
load_all()

# Use a summary GHG model
model <- useeior::buildModel("USEEIOv2.0-s-GHG")


# First check that calculateEEIOModel with FINAL perspective and use_domestic_requirements=TRUE is the same as manual calculation

LCI_final <- calculateEEIOModel(model, perspective = "FINAL", demand = "Consumption", use_domestic_requirements = TRUE)$LCI_f


LCI_final_check <- calculateFinalPerspectiveLCI(model$M_d,model$DemandVectors$vectors$`2012_US_Consumption_Domestic`)
all.equal(LCI_final,LCI_final_check)

> TRUE

## LCI colsums (sum by flow) should be the same in both FINAL or DIRECT calcs. Check this is true.

LCI_final_sum <- colSums(LCI_final)

LCI_direct <- calculateEEIOModel(model, perspective = "DIRECT", demand = "Consumption", use_domestic_requirements = TRUE)$LCI_d

LCI_direct_sum <- colSums(LCI_direct)

all.equal(LCI_final_sum,LCI_direct_sum)

>TRUE

```