### PR TITLE
Adds option for results matrix to include `RoW` region as new rows

### DIFF
--- a/R/CalculationFunctions.R
+++ b/R/CalculationFunctions.R
@@ -133,12 +133,7 @@ calculateResultsWithExternalFactors <- function(model, perspective = "FINAL", de
   result <- list()
   y_d <- prepareDemandVectorForStandardResults(model, demand, location = location, use_domestic_requirements = TRUE)
   y_m <- prepareDemandVectorForImportResults(model, demand, location = location)
-  
-  if(household_emissions) {
-    hh <- calculateHouseholdEmissions(model, f=(y_d + y_m), location, characterized=FALSE)
-    hh_lcia <- calculateHouseholdEmissions(model, f=(y_d + y_m), location, characterized=TRUE)
-  }
-  
+
   if(show_RoW) {
     if(model$specs$IODataSource=="stateior") {
       sector_count <- nrow(y_d)/2
@@ -211,6 +206,8 @@ calculateResultsWithExternalFactors <- function(model, perspective = "FINAL", de
     
   # Add household emissions to results if applicable
   if(household_emissions) {
+    hh <- calculateHouseholdEmissions(model, f=(y_d + y_m), location, characterized=FALSE)
+    hh_lcia <- calculateHouseholdEmissions(model, f=(y_d + y_m), location, characterized=TRUE)
     LCI <- rbind(LCI, hh)
     LCIA <- rbind(LCIA, hh_lcia)
   }

--- a/R/CalculationFunctions.R
+++ b/R/CalculationFunctions.R
@@ -13,14 +13,16 @@
 #' @param use_domestic_requirements A logical value: if TRUE, use domestic demand and L_d matrix;
 #' if FALSE, use complete demand and L matrix.
 #' @param household_emissions, bool, if TRUE, include calculation of emissions from households
+#' @param show_RoW, bool, if TRUE, include rows for commodities in RoW, e.g. `111CA/RoW` in result objects.
+#'  Only valid currently for models with ExternalImportFactors. 
 #' @export
 #' @return A list with LCI and LCIA results (in data.frame format) of the EEIO model.
 calculateEEIOModel <- function(model, perspective, demand = "Production", location = NULL,
-                               use_domestic_requirements = FALSE, household_emissions = FALSE) {
+                               use_domestic_requirements = FALSE, household_emissions = FALSE, show_RoW = FALSE) {
   if (!is.null(model$specs$ExternalImportFactors) && model$specs$ExternalImportFactors) {
     result <- calculateResultsWithExternalFactors(model, perspective, demand, location = location,
                                                   use_domestic_requirements = use_domestic_requirements,
-                                                  household_emissions = household_emissions)
+                                                  household_emissions = household_emissions, show_RoW = show_RoW)
   } else {
     # Standard model results calculation
     f <- prepareDemandVectorForStandardResults(model, demand, location, use_domestic_requirements)
@@ -125,7 +127,8 @@ prepareDemandVectorForImportResults <- function(model, demand = "Production", lo
 #' @param household_emissions, bool, if TRUE, include calculation of emissions from households
 #' @return A list with LCI and LCIA results (in data.frame format) of the EEIO model.
 calculateResultsWithExternalFactors <- function(model, perspective = "FINAL", demand = "Consumption", location = NULL,
-                                                use_domestic_requirements = FALSE, household_emissions = FALSE) {
+                                                use_domestic_requirements = FALSE, household_emissions = FALSE,
+                                                show_RoW = FALSE) {
   result <- list()
   y_d <- prepareDemandVectorForStandardResults(model, demand, location = location, use_domestic_requirements = TRUE)
   y_m <- prepareDemandVectorForImportResults(model, demand, location = location)
@@ -135,14 +138,17 @@ calculateResultsWithExternalFactors <- function(model, perspective = "FINAL", de
     hh_lcia <- calculateHouseholdEmissions(model, f=(y_d + y_m), location, characterized=TRUE)
   }
   
-  if(model$specs$IODataSource=="stateior") {
-    row_names <- c(colnames(model$M_m),
-                   gsub("/.*", "/RoW", colnames(model$M_m[, 1:(nrow(y_d)/2)])))
+  if(show_RoW) {
+    if(model$specs$IODataSource=="stateior") {
+      row_names <- c(colnames(model$M_m),
+                     gsub("/.*", "/RoW", colnames(model$M_m[, 1:(nrow(y_d)/2)])))
+    } else {
+      row_names <- c(colnames(model$M_m),
+                     gsub("/.*", "/RoW", colnames(model$M_m)))
+    }
   } else {
-    row_names <- c(colnames(model$M_m),
-                   gsub("/.*", "/RoW", colnames(model$M_m)))
+    row_names <- colnames(model$M_m)
   }
-
   # Calculate Final perspective results
   if(perspective == "FINAL") {
     # Calculate Final Perspective LCI (a matrix with total impacts in form of sector x flows)
@@ -158,14 +164,18 @@ calculateResultsWithExternalFactors <- function(model, perspective = "FINAL", de
       r3[] <- 0
     }
     
-    if(model$specs$IODataSource=="stateior") {
-      # collapse third term for SoI and RoUS
-      z <- r3[, 1:(ncol(r3)/2)] + r3[, ((ncol(r3)/2)+1):ncol(r3)]
-      # rowSums(z) == rowSums(r3)
-      r3 <- z
+    if(show_RoW) {
+      if(model$specs$IODataSource=="stateior") {
+        # collapse third term for SoI and RoUS
+        z <- r3[, 1:(ncol(r3)/2)] + r3[, ((ncol(r3)/2)+1):ncol(r3)]
+        # rowSums(z) == rowSums(r3)
+        r3 <- z
+      }
+      result$LCI_f <- cbind(r1 + r2, r3) # Term 3 is assigned to RoW  
+    } else {
+      result$LCI_f <- r1 + r2 + r3 # Term 3 is assigned to RoW  
     }
-
-    result$LCI_f <- cbind(r1 + r2, r3) # Term 3 is assigned to RoW
+    
     # Calculate Final Perspective LCIA (matrix with direct impacts in form of sector x impacts)
     logging::loginfo("Calculating Final Perspective LCIA with external import factors...")
     result$LCIA_f <- model$C %*% result$LCI_f
@@ -197,17 +207,20 @@ calculateResultsWithExternalFactors <- function(model, perspective = "FINAL", de
       r3[] <- 0
     }
     
-    if(model$specs$IODataSource=="stateior") {
-      # collapse second and third term for SoI and RoUS
-      z <- r3[1:(nrow(r3)/2), ] + r3[((nrow(r3)/2)+1):nrow(r3), ]
-      # colSums(z) == colSums(r3)
-      r3 <- z
-      z <- r2[1:(nrow(r2)/2), ] + r2[((nrow(r2)/2)+1):nrow(r2), ]
-      # colSums(z) == colSums(r2)
-      r2 <- z
-    }
-
-    result$LCI_d <- rbind(r1, r2 + r3) # Term 2 and Term 3 are assigned to RoW
+    if(show_RoW) {
+      if(model$specs$IODataSource=="stateior") {
+        # collapse second and third term for SoI and RoUS
+        z <- r3[1:(nrow(r3)/2), ] + r3[((nrow(r3)/2)+1):nrow(r3), ]
+        # colSums(z) == colSums(r3)
+        r3 <- z
+        z <- r2[1:(nrow(r2)/2), ] + r2[((nrow(r2)/2)+1):nrow(r2), ]
+        # colSums(z) == colSums(r2)
+        r2 <- z
+      }
+      result$LCI_d <- cbind(r1, r2 + r3) # Term 2 and Term 3 are assigned to RoW
+    } else {
+      result$LCI_d <- r1 + r2 + r3 # All three terms combined and regions do not change
+    }  
     # Calculate Direct Perspective LCIA (matrix with direct impacts in form of sector x impacts)
     logging::loginfo("Calculating Direct Perspective LCIA with external import factors...")
     result$LCIA_d <- model$C %*% t(result$LCI_d)

--- a/R/CalculationFunctions.R
+++ b/R/CalculationFunctions.R
@@ -14,7 +14,7 @@
 #' if FALSE, use complete demand and L matrix.
 #' @param household_emissions, bool, if TRUE, include calculation of emissions from households
 #' @param show_RoW, bool, if TRUE, include rows for commodities in RoW, e.g. `111CA/RoW` in result objects.
-#'  Only valid currently for models with ExternalImportFactors. 
+#' Only valid currently for models with ExternalImportFactors.
 #' @export
 #' @return A list with LCI and LCIA results (in data.frame format) of the EEIO model.
 calculateEEIOModel <- function(model, perspective, demand = "Production", location = NULL,
@@ -125,6 +125,7 @@ prepareDemandVectorForImportResults <- function(model, demand = "Production", lo
 #' @param location, str optional location code for demand vector, required for two-region models
 #' @param use_domestic_requirements bool, if TRUE, return only domestic portion of results
 #' @param household_emissions, bool, if TRUE, include calculation of emissions from households
+#' @param show_RoW, bool, if TRUE, include rows for commodities in RoW, e.g. `111CA/RoW` in result objects.
 #' @return A list with LCI and LCIA results (in data.frame format) of the EEIO model.
 calculateResultsWithExternalFactors <- function(model, perspective = "FINAL", demand = "Consumption", location = NULL,
                                                 use_domestic_requirements = FALSE, household_emissions = FALSE,

--- a/R/CalculationFunctions.R
+++ b/R/CalculationFunctions.R
@@ -146,20 +146,21 @@ calculateResultsWithExternalFactors <- function(model, perspective = "FINAL", de
     r3 <- model$M_m %*% diag(as.vector(y_m))
     
     if (use_domestic_requirements) {
-      result$LCI_f <- r1
-    } else {
-      result$LCI_f <- r1 + r2 + r3
+      r2[] <- 0
+      r3[] <- 0
     }
+    result$LCI_f <- cbind(r1 + r2, r3) # Term 3 is assigned to RoW
     # Calculate Final Perspective LCIA (matrix with direct impacts in form of sector x impacts)
     logging::loginfo("Calculating Final Perspective LCIA with external import factors...")
     result$LCIA_f <- model$C %*% result$LCI_f
     result$LCI_f <- t(result$LCI_f)
     result$LCIA_f <- t(result$LCIA_f)
     
+    row_names <- c(colnames(model$M_m), gsub("/US", "/RoW", colnames(model$M_m)))
     colnames(result$LCI_f) <- rownames(model$M_m)
-    rownames(result$LCI_f) <- colnames(model$M_m)
+    rownames(result$LCI_f) <- row_names
     colnames(result$LCIA_f) <- rownames(model$D)
-    rownames(result$LCIA_f) <- colnames(model$D)
+    rownames(result$LCIA_f) <- row_names
     
     # Add household emissions to results if applicable
     if(household_emissions) {
@@ -177,20 +178,20 @@ calculateResultsWithExternalFactors <- function(model, perspective = "FINAL", de
     r3 <- t(model$M_m %*% diag(as.vector(y_m))) # Emissions from imported goods consumed as final products
     
     if (use_domestic_requirements) {
-      result$LCI_d <- r1
-    } else {
-      result$LCI_d <- r1 + r2 + r3
+      r2[] <- 0
+      r3[] <- 0
     }
-
+    result$LCI_d <- rbind(r1, r2 + r3) # Term 2 and Term 3 are assigned to RoW
     # Calculate Direct Perspective LCIA (matrix with direct impacts in form of sector x impacts)
     logging::loginfo("Calculating Direct Perspective LCIA with external import factors...")
     result$LCIA_d <- model$C %*% t(result$LCI_d)
     result$LCIA_d <- t(result$LCIA_d)
     
+    row_names <- c(colnames(model$M_m), gsub("/US", "/RoW", colnames(model$M_m)))
     colnames(result$LCI_d) <- rownames(model$M_m)
-    rownames(result$LCI_d) <- colnames(model$M_m)    
+    rownames(result$LCI_d) <- row_names    
     colnames(result$LCIA_d) <- rownames(model$D)
-    rownames(result$LCIA_d) <- colnames(model$D)
+    rownames(result$LCIA_d) <- row_names
 
     # Add household emissions to results if applicable
     if(household_emissions) {

--- a/R/CalculationFunctions.R
+++ b/R/CalculationFunctions.R
@@ -217,7 +217,7 @@ calculateResultsWithExternalFactors <- function(model, perspective = "FINAL", de
         # colSums(z) == colSums(r2)
         r2 <- z
       }
-      result$LCI_d <- cbind(r1, r2 + r3) # Term 2 and Term 3 are assigned to RoW
+      result$LCI_d <- rbind(r1, r2 + r3) # Term 2 and Term 3 are assigned to RoW
     } else {
       result$LCI_d <- r1 + r2 + r3 # All three terms combined and regions do not change
     }  

--- a/R/CalculationFunctions.R
+++ b/R/CalculationFunctions.R
@@ -559,6 +559,10 @@ calculateHouseholdEmissions <- function(model, f, location, characterized=FALSE)
     logging::logwarn("Household emissions not found in this model")
     return(NULL)
   }
+  if(length(model$specs$ModelRegionAcronyms) == 1) {
+    # Set location as NULL for single region model
+    location <- NULL
+  }
   codes <- model$FinalDemandMeta[model$FinalDemandMeta$Group%in%c("Household"), "Code_Loc"]
   if (!is.null(location)) {
     other_code <- codes[!grepl(location, codes)]

--- a/man/calculateEEIOModel.Rd
+++ b/man/calculateEEIOModel.Rd
@@ -11,7 +11,8 @@ calculateEEIOModel(
   demand = "Production",
   location = NULL,
   use_domestic_requirements = FALSE,
-  household_emissions = FALSE
+  household_emissions = FALSE,
+  show_RoW = FALSE
 )
 }
 \arguments{
@@ -31,6 +32,9 @@ numeric values in USD with the same dollar year as model.}
 if FALSE, use complete demand and L matrix.}
 
 \item{household_emissions, }{bool, if TRUE, include calculation of emissions from households}
+
+\item{show_RoW, }{bool, if TRUE, include rows for commodities in RoW, e.g. `111CA/RoW` in result objects.
+Only valid currently for models with ExternalImportFactors.}
 }
 \value{
 A list with LCI and LCIA results (in data.frame format) of the EEIO model.

--- a/man/calculateHouseholdEmissions.Rd
+++ b/man/calculateHouseholdEmissions.Rd
@@ -4,7 +4,13 @@
 \alias{calculateHouseholdEmissions}
 \title{Calculate household emissions from B_h}
 \usage{
-calculateHouseholdEmissions(model, f, location, characterized = FALSE)
+calculateHouseholdEmissions(
+  model,
+  f,
+  location,
+  characterized = FALSE,
+  show_RoW = FALSE
+)
 }
 \arguments{
 \item{model}{A complete EEIO model: a list with USEEIO model components and attributes.}
@@ -15,6 +21,9 @@ numeric values in USD with the same dollar year as model.}
 \item{location, }{str optional location code for demand vector, required for two-region models}
 
 \item{characterized, }{bool, TRUE to characterize using C matrix, FALSE to show LCI}
+
+\item{show_RoW, }{bool, if TRUE, include rows for commodities in RoW, e.g. `111CA/RoW` in result objects.
+Only valid currently for models with ExternalImportFactors.}
 }
 \value{
 A result vector with rows for final demand sector(s)

--- a/man/calculateResultsWithExternalFactors.Rd
+++ b/man/calculateResultsWithExternalFactors.Rd
@@ -12,7 +12,8 @@ calculateResultsWithExternalFactors(
   demand = "Consumption",
   location = NULL,
   use_domestic_requirements = FALSE,
-  household_emissions = FALSE
+  household_emissions = FALSE,
+  show_RoW = FALSE
 )
 }
 \arguments{
@@ -29,6 +30,8 @@ results with the sectors consumed by the final user.}
 \item{use_domestic_requirements}{bool, if TRUE, return only domestic portion of results}
 
 \item{household_emissions, }{bool, if TRUE, include calculation of emissions from households}
+
+\item{show_RoW, }{bool, if TRUE, include rows for commodities in RoW, e.g. `111CA/RoW` in result objects.}
 }
 \value{
 A list with LCI and LCIA results (in data.frame format) of the EEIO model.


### PR DESCRIPTION
Only valid for models with `ExternalImportFactors` (both one or two-region models)

 ```
calculateEEIOModel(..., show_RoW = TRUE)
```